### PR TITLE
Fix memory corruption, related to unitialized currentPlay

### DIFF
--- a/deps/LFO.cpp
+++ b/deps/LFO.cpp
@@ -19,6 +19,10 @@ LowFrequencyOscillator::LowFrequencyOscillator() {
   srand(time(NULL));
 }
 
+LowFrequencyOscillator::~LowFrequencyOscillator() {
+  delete cv;
+}
+
 void LowFrequencyOscillator::setPitch(float pitch) {
   pitch = fminf(pitch, 8.0);
   freq = powf(2.0, pitch);

--- a/deps/LFO.hpp
+++ b/deps/LFO.hpp
@@ -18,6 +18,7 @@ private:
 
 public:
   LowFrequencyOscillator();
+  ~LowFrequencyOscillator();
   void setPitch(float);
   void setFrequency(float);
   void setPulseWidth(float);

--- a/src/controller/Baronial.cpp
+++ b/src/controller/Baronial.cpp
@@ -26,6 +26,10 @@ BaronialModule::BaronialModule() {
   configParam<Slope>(RELEASE_CURVE_PARAM, 0.0, 1.0, 1.0);
 }
 
+BaronialModule::~BaronialModule() {
+  delete gate;
+}
+
 void BaronialModule::process(const ProcessArgs &args) {
   if (inputs[GATE].isConnected()) {
     gate->update(inputs[GATE].getVoltage());

--- a/src/controller/Baronial.hpp
+++ b/src/controller/Baronial.hpp
@@ -13,6 +13,7 @@ struct BaronialModule : Module {
   enum LightIds { NUM_LIGHTS };
 
   BaronialModule();
+  ~BaronialModule() override;
   float paramValue (uint16_t, uint16_t, float, float);
 
   void process(const ProcessArgs &args) override;

--- a/src/controller/Gnome.cpp
+++ b/src/controller/Gnome.cpp
@@ -16,6 +16,12 @@ GnomeModule::GnomeModule () {
   doReset();
 }
 
+GnomeModule::~GnomeModule() {
+  delete reset;
+  delete runCV;
+  delete runParam;
+}
+
 void GnomeModule::doReset() {
   bpm = 0;
   width = 0;

--- a/src/controller/Gnome.hpp
+++ b/src/controller/Gnome.hpp
@@ -10,6 +10,7 @@ struct GnomeModule : Module {
   enum LightIds { LED_1, LED_2, LED_4, LED_8, LED_16, LED_A, LED_B, LED_C, LED_D, LED_E, LED_F, LED_RESET, RUN_LIGHT, NUM_LIGHTS };
 
   GnomeModule( );
+  ~GnomeModule();
   float paramValue (uint16_t, uint16_t, float, float);
   void process(const ProcessArgs &args) override;
 

--- a/src/controller/Marionette.cpp
+++ b/src/controller/Marionette.cpp
@@ -28,6 +28,10 @@ MarionetteModule::MarionetteModule( ) {
   freqAdsr.setDecayCurve(CURVED);
 }
 
+MarionetteModule::~MarionetteModule() {
+  delete gate;
+}
+
 float MarionetteModule::paramValue (uint16_t param, uint16_t input, float low, float high) {
   float current = params[param].getValue();
 

--- a/src/controller/Marionette.hpp
+++ b/src/controller/Marionette.hpp
@@ -45,6 +45,7 @@ struct MarionetteModule : Module {
   enum LightIds { NUM_LIGHTS };
 
   MarionetteModule();
+  ~MarionetteModule() override;
   void process(const ProcessArgs &) override;
 
   float pitchEnvelope ( );

--- a/src/controller/OpenHH.cpp
+++ b/src/controller/OpenHH.cpp
@@ -31,6 +31,11 @@ OpenHHModule::OpenHHModule( ) {
   chokeCV[1] = new SynthDevKit::CV(0.5);
 }
 
+OpenHHModule::~OpenHHModule() {
+  delete chokeCV[0];
+  delete chokeCV[1];
+}
+
 float OpenHHModule::chokeValue(uint8_t which, uint32_t sampleRate) {
   if (choking[which] == false) {
     return 1;

--- a/src/controller/OpenHH.hpp
+++ b/src/controller/OpenHH.hpp
@@ -3,6 +3,7 @@
 
 struct OpenHHModule : SampleController {
   OpenHHModule();
+  ~OpenHHModule() override;
   void setupSamples( ) override;
   uint8_t sampleId(uint8_t) override;
   float chokeValue(uint8_t, uint32_t);

--- a/src/controller/SBD.cpp
+++ b/src/controller/SBD.cpp
@@ -16,6 +16,11 @@ SBDModule::SBDModule( ) {
   configParam<WaveShape>(SBDModule::WAVE_PARAM, 0.0, 1.0, 1.0, "Wave");
 }
 
+SBDModule::~SBDModule() {
+  delete cv;
+  delete noise;
+}
+
 void SBDModule::process(const ProcessArgs &args) {
   float noiseVal = 0.0f;
   float freq_decay = params[PITCH_DECAY_PARAM].getValue();

--- a/src/controller/SBD.hpp
+++ b/src/controller/SBD.hpp
@@ -15,6 +15,7 @@ struct SBDModule : Module {
   enum LightIds { NUM_LIGHTS };
 
   SBDModule( );
+  ~SBDModule() override;
   void process(const ProcessArgs &) override;
 
   LowFrequencyOscillator lfo;

--- a/src/controller/SampleController.cpp
+++ b/src/controller/SampleController.cpp
@@ -9,6 +9,11 @@ SampleController::SampleController( ) {
   numModules = 0;
 }
 
+SampleController::~SampleController() {
+  for (uint8_t i = 0; i < MAX_MODULES; i++)
+    delete cv[i];
+}
+
 float SampleController::paramValue (uint16_t param, uint16_t input, float low, float high) {
   float current = params[param].getValue();
 

--- a/src/controller/SampleController.hpp
+++ b/src/controller/SampleController.hpp
@@ -16,6 +16,7 @@ struct SampleController : Module {
   enum LightIds { NUM_LIGHTS };
 
   SampleController( );
+  ~SampleController() override;
   void process(const ProcessArgs &) override;
   float paramValue (uint16_t, uint16_t, float, float);
   virtual void setupSamples( );

--- a/src/controller/Sequencer.cpp
+++ b/src/controller/Sequencer.cpp
@@ -67,6 +67,23 @@ SequencerModule::SequencerModule() {
   doReset();
 }
 
+SequencerModule::~SequencerModule() {
+  delete clock;
+  delete runCV;
+  delete runParam;
+  delete cycleCV;
+  delete cycleParam;
+  delete resetCV;
+  delete mainUp;
+  delete mainDown;
+  delete copy;
+  delete paste;
+  for (int i = 0; i < SEQ_PLAY; i++) {
+    delete patternUp[i];
+    delete patternDown[i];
+  }
+}
+
 void SequencerModule::doReset() {
   currentCount = -1;
   currentGate = -1;

--- a/src/controller/Sequencer.cpp
+++ b/src/controller/Sequencer.cpp
@@ -56,8 +56,6 @@ SequencerModule::SequencerModule() {
     }
   }
 
-  doReset();
-
   configParam<PercentTen>(PULSE_WIDTH, 0.1, 10.0, 5.05, "Width", "%");
   configParam<Blank>(PLAY, 0.0f, 1.0f, 0.0f, "Run");
   configParam<Blank>(CYCLE, 0.0f, 1.0f, 0.0f, "Cycle");
@@ -65,14 +63,17 @@ SequencerModule::SequencerModule() {
   configParam<Blank>(MAIN_DOWN, 0.0f, 1.0f, 0.0f, "Down");
   configParam<Blank>(COPY, 0.0f, 1.0f, 0.0f, "Copy");
   configParam<Blank>(PASTE, 0.0f, 1.0f, 0.0f, "Paste");
+
+  doReset();
 }
 
 void SequencerModule::doReset() {
   currentCount = -1;
+  currentGate = -1;
+  currentPlay = 1;
+  currentPosition = 0;
   savePattern(currentPlay);
   setPlay(programs[0]);
-  currentGate = -1;
-  currentPosition = 0;
 }
 
 json_t *SequencerModule::dataToJson() {

--- a/src/controller/Sequencer.hpp
+++ b/src/controller/Sequencer.hpp
@@ -48,6 +48,7 @@ struct SequencerModule : Module {
   };
 
   SequencerModule( );
+  ~SequencerModule() override;
 
   void process(const ProcessArgs &) override;
   json_t *dataToJson() override;

--- a/src/model/SampleManager.cpp
+++ b/src/model/SampleManager.cpp
@@ -40,6 +40,10 @@ namespace DrumKit {
 
     mantissa = modf(ctx->currentPosition, &characteristic);
 
+    if ((uint64_t) characteristic == 0) {
+      return 0.0f;
+    }
+
     if (mantissa == 0) {
       return ctx->sample->values[(uint64_t) characteristic - 1];
     }


### PR DESCRIPTION
Under certain conditions, loading a project with DrumKit Sequencer on it would cause a crash.
Main issue seems to be that `currentPlay` is not initialized during constructor, so random stuff would just go wrong..

See related discussion at https://github.com/DISTRHO/Cardinal/issues/225

Patch fixes the crash, reordering some minor things for looking better and also in a way that makes sense.
